### PR TITLE
REST_BLOCK_AT need to request /block/at/public

### DIFF
--- a/src/main/java/org/nem/core/node/NisPeerId.java
+++ b/src/main/java/org/nem/core/node/NisPeerId.java
@@ -11,7 +11,7 @@ public enum NisPeerId implements ApiId {
 	/**
 	 * The block/at API.
 	 */
-	REST_BLOCK_AT("/block/at"),
+	REST_BLOCK_AT("/block/at/public"),
 
 	//endregion
 


### PR DESCRIPTION
As documented at http://bob.nem.ninja/docs/#getting-a-block-with-a-given-height
Sending request to /block/at results in a 500 Internal Server Error